### PR TITLE
Ensure that the LICENSE file is included in wheels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[metadata]
+license_file = LICENSE


### PR DESCRIPTION
Without this, it is not added to a wheel.

Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>